### PR TITLE
Removed timeslave argument

### DIFF
--- a/net/serval-mesh-extender/files/etc/serval/runlbard
+++ b/net/serval-mesh-extender/files/etc/serval/runlbard
@@ -37,7 +37,7 @@ do
 
   if [ ! -e /dos/nouhf ]; then
     # Run LBARD
-    lbard 127.0.0.1:4110 lbard:lbard `servald keyring list | tail -1 | cut -f1 -d:` `servald keyring list | tail -1 | cut -f2 -d:` /dev/ttyATH0 timeslave udptime logrejects meshmsonly otadir=/serval flags=1 bundlelog=/serval-var/lbard.log $otabid fixfs # rebootwhenstuck periodicrequests=/etc/serval/lbard-restful.conf 
+    lbard 127.0.0.1:4110 lbard:lbard `servald keyring list | tail -1 | cut -f1 -d:` `servald keyring list | tail -1 | cut -f2 -d:` /dev/ttyATH0 udptime logrejects meshmsonly otadir=/serval flags=1 bundlelog=/serval-var/lbard.log $otabid fixfs # rebootwhenstuck periodicrequests=/etc/serval/lbard-restful.conf
     # If LBARD stops or dies, try reflashing the radio incase flashing it on boot failed.
     # (we have seen this happen once)
     # flash900 /etc/serval/rfd900 /dev/ttyATH0


### PR DESCRIPTION
This was causing bad time propagation issues where one device could poison the whole network via HF/UHF